### PR TITLE
fix: types issues for deploy

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -24,7 +24,7 @@ const Nav = () => {
             {tabs.map((tab, index) => (
                 <button
                     key={tab}
-                    ref={el => tabRefs.current[index] = el}
+                    ref={el => {tabRefs.current[index] = el;}}
                     onClick={() => setSelected(index)}
                     className={`relative cursor-pointer ${index === selected ? 'text-[#FFEE00]' : 'text-[#D9D9D9]'}`}
                 >

--- a/src/hooks/useFetchUpcoming.ts
+++ b/src/hooks/useFetchUpcoming.ts
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react"
+import type { Order } from "../types/order"
 
 const useFetchUpcoming = () => {
-    const [ordersUpcoming, setOrdersUpcoming] = useState([])
+    const [ordersUpcoming, setOrdersUpcoming] = useState<Order[]>([])
 
     useEffect(() => {
         const fetchUpcoming = async () => {

--- a/src/types/destination.ts
+++ b/src/types/destination.ts
@@ -1,0 +1,7 @@
+export type Destination = {
+    address: string;
+    start_date: number;
+    end_date: number;
+    nickname: string;
+    show_navigation: boolean;
+};

--- a/src/types/order.ts
+++ b/src/types/order.ts
@@ -1,0 +1,16 @@
+export type Order = {
+    _id: string;
+    status: number;
+    order_number: string;
+    manager: string;
+    driver: string;
+    version: string;
+    type: string;
+    destinations: Destination[];
+    start_date: number;
+    end_date: number;
+    is_today: boolean;
+    status_string: string;
+    status_class: string;
+    driver_thumbnail: string | null;
+};


### PR DESCRIPTION
This pull request introduces several changes to improve type safety, enhance code readability, and expand type definitions. The most important updates include adding new type definitions for `Order` and `Destination`, updating state initialization in `useFetchUpcoming` to use the `Order` type, and making a minor adjustment to the `Nav` component for better readability.

### Type Definitions:
* [`src/types/order.ts`](diffhunk://#diff-fa5538163d5082879a33d44a4c26a8cec88836943094271ab5954a146000eba9R1-R16): Added a comprehensive `Order` type definition, including fields such as `_id`, `status`, `order_number`, `manager`, `driver`, and related metadata.
* [`src/types/destination.ts`](diffhunk://#diff-53f8c6f73507de726aa3d4ea902919880365a2b8f0cdcc726d4574e1741e836aR1-R7): Added a `Destination` type definition to represent destination-related data, including `address`, `start_date`, `end_date`, and `nickname`.

### Type Safety Enhancements:
* [`src/hooks/useFetchUpcoming.ts`](diffhunk://#diff-f91f4305d3796caaca9e599235af3288f9488de27587ee2361d47bb34bddc676R2-R5): Updated the `ordersUpcoming` state initialization to use the newly defined `Order` type, ensuring type safety for the `useFetchUpcoming` hook.

### Code Readability:
* [`src/components/Nav.tsx`](diffhunk://#diff-7f2ef60bbec771e3e2a3e1e7162d91e481d7724cd76ea86a82a0b4ad45c3baefL27-R27): Adjusted the `ref` assignment in the `Nav` component to use a block-style function for improved readability.