### PR TITLE
fix: centered as grid

### DIFF
--- a/src/components/CargoOrders/OrderCard/OrderCard.tsx
+++ b/src/components/CargoOrders/OrderCard/OrderCard.tsx
@@ -19,7 +19,7 @@ const OrderCard = ({order}: OrderCardProps) => {
     const inTransit = isInTransit();
 
     return (
-        <div className="!mx-[40px] !mb-[39px] w-[349px] h-[336px] flex flex-col">
+        <div className="!mx-[40px] !mb-[39px] w-[347px] h-[336px] flex flex-col">
             <OrderHeader orderNumber={order.order_number} />
             <div className="relative bg-black rounded-[20px]">
                 <OrderStatusBar inTransit={inTransit} />

--- a/src/pages/CargoOrder.tsx
+++ b/src/pages/CargoOrder.tsx
@@ -26,7 +26,7 @@ const CargoOrders = () => {
         <main className="flex flex-col">
             <Nav selected={selectedTab} setSelected={setSelectedTab} />
             <SearchBar searchTerm={searchTerm} onSearch={setSearchTerm} />
-            <section className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 items-center justify-center mx-auto w-full max-w-7xl">
+            <section className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 place-items-center mx-auto w-full max-w-7xl">
                 {filteredOrders.map((order) => (
                     <OrderCard key={order._id} order={order} />
                 ))}


### PR DESCRIPTION
This pull request includes minor updates to the layout styling in the `CargoOrders` module, focusing on improving alignment and spacing.

Styling adjustments:

* [`src/components/CargoOrders/OrderCard/OrderCard.tsx`](diffhunk://#diff-8993be015d0e92711d08b0a5c697ff1b04aea99fb2ce7e5c1a811418e7833de2L22-R22): Updated the width of the `OrderCard` container from `349px` to `347px` for better alignment within its parent layout.
* [`src/pages/CargoOrder.tsx`](diffhunk://#diff-f62b5e05b987c29597ffa85b03244873cbd78a7856223875d597899e1c748fdfL29-R29): Changed the `section` element's CSS class from `items-center` to `place-items-center` to enhance alignment consistency across different grid layouts.